### PR TITLE
Adding two new properties and updating general information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
-# vRank
-Vocabulary for Ranking
+# vRank - Vocabulary for Ranking
 
 The Vocabulary for Ranking (vRank) is an RDF Schema vocabulary for materializing ranking computations.
 
 If you use this work, please mention it in your references:
 
   ```
-  @Inproceedings{j.2012tafmfsarrc,
-  booktitle = {Proceedings of the 6th International Workshop on Ranking in Databases (DBRank 2012) held in conjunction with the 38th Conference on Very Large Databases (VLDB 2012)},
-  publisher = {online},
-  title = {Towards a formal model for sharing and reusing ranking computations},
-  year = {2012},
-  type = {Inproceedings},
-  author = {Antonio J. Roa-Valverde and Andreas Thalhammer and Ioan Toma and Miguel-Angel Sicilia},
-  evastar_pdf = {Dbrank2012.pdf}
+@InProceedings{roa-valverde,
+  Title                    = {{Towards a formal model for sharing and reusing ranking computations}},
+  Author                   = {Roa-Valverde, Antonio J. and Thalhammer, Andreas and Toma, Ioan and Sicilia,Miguel-Angel},
+  Booktitle                = {Proceedings of the 6th International Workshop on Ranking in Databases (DBRank 2012) held in conjunction with the 38th Conference on Very Large Databases (VLDB 2012)},
+  Year                     = {2012},
+  Url                      = {http://km.aifb.kit.edu/services/summa/dbrank2012.pdf}
+}
   }
   ```
+
+# Changelog
+* v2.0 
+* v1.0 Initial release of vRank, 2012-06-05
+

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ If you use this work, please mention it in your references:
   Year                     = {2012},
   Url                      = {http://km.aifb.kit.edu/services/summa/dbrank2012.pdf}
 }
-  }
   ```
 
 # Changelog

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ If you use this work, please mention it in your references:
   ```
 
 # Changelog
-* v2.0 
-* v1.0 Initial release of vRank, 2012-06-05
+* __v2.0 (2017-10-31)__ Adding support for relating owl:Thing to ranking values directly. More specifically, the properties vrank:simpleRank and vrank:pagerank were added.
+* __v1.0 (2012-06-05)__ Initial release of vRank.
 

--- a/vrank.rdf
+++ b/vrank.rdf
@@ -130,7 +130,7 @@
     <rdfs:label>has feature</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="http://purl.org/voc/vrank#hasFeature">
-    <rdfs:comment>TODO.</rdfs:comment>
+    <rdfs:comment>Relates vrank:Algorithm with vrank:Feature.</rdfs:comment>
   </rdf:Description>
   <rdf:Description rdf:about="http://purl.org/voc/vrank#hasFeature">
     <rdfs:domain rdf:resource="http://purl.org/voc/vrank#Algorithm"/>
@@ -145,7 +145,7 @@
     <rdfs:label>has parameter</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="http://purl.org/voc/vrank#hasParameter">
-    <rdfs:comment>TODO.</rdfs:comment>
+    <rdfs:comment>Relates vrank:Algorithm with vrank:Parameter.</rdfs:comment>
   </rdf:Description>
   <rdf:Description rdf:about="http://purl.org/voc/vrank#hasParameter">
     <rdfs:domain rdf:resource="http://purl.org/voc/vrank#Algorithm"/>
@@ -280,7 +280,7 @@
     <rdfs:label>pagerank</rdfs:label>
   </rdf:Description>
   <rdf:Description rdf:about="http://purl.org/voc/vrank#pagerank">
-    <rdfs:comment>Directly connects owl:Thing with PageRrank values.</rdfs:comment>
+    <rdfs:comment>Directly connects owl:Thing with PageRank values.</rdfs:comment>
   </rdf:Description>
   <rdf:Description rdf:about="http://purl.org/voc/vrank#pagerank">
     <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>

--- a/vrank.rdf
+++ b/vrank.rdf
@@ -1,172 +1,375 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-  xmlns:owl="http://www.w3.org/2002/07/owl#"
-  xmlns:dcterms="http://purl.org/dc/terms/"
-  xmlns:vann="http://purl.org/vocab/vann/"
-  xmlns:foaf="http://xmlns.com/foaf/0.1/"
-  xmlns:dc="http://purl.org/dc/elements/1.1/"
-  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
-
-  <owl:Ontology rdf:about="http://vocab.sti2.at/vrank">
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:vann="http://purl.org/vocab/vann/" xmlns:vrank="http://purl.org/voc/vrank#" xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
     <dcterms:title>Vocabulary for Ranking (vRank)</dcterms:title>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
     <dcterms:description>The Vocabulary for Ranking (vRank) is an RDF Schema vocabulary for materializing ranking computations.</dcterms:description>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2012-06-05</dcterms:modified>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2017-10-31</dcterms:modified>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
     <vann:preferredNamespaceUri>http://purl.org/voc/vrank#</vann:preferredNamespaceUri>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
     <vann:preferredNamespacePrefix>vrank</vann:preferredNamespacePrefix>
-    <foaf:homepage rdf:resource="http://vocab.sti2.at/vrank.html"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+    <foaf:homepage rdf:resource="https://github.com/6020peaks/vRank"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2012-06-05</dcterms:created>
-    <dcterms:publisher>http://vocab.sti2.at/vrank#STI%20Innsbruck</dcterms:publisher>
-    <dcterms:partOf rdf:resource="http://vocab.sti2.at"/>
-    <dcterms:type rdf:resource="http://purl.org/adms/assettype/Ontology"/>
-    <dcterms:status rdf:resource="http://purl.org/adms/status/UnderDevelopment"/>
-    <dc:creator rdf:resource="http://vocab.sti2.at/vrank#andtha"/>
-    <dc:creator rdf:resource="http://vocab.sti2.at/vrank#aroa"/>
-    <dc:creator rdf:resource="http://vocab.sti2.at/vrank#itoma"/>
-  </owl:Ontology>
-
-  <rdf:Description rdf:about="http://vocab.sti2.at/vrank#ttl">
-    <dcterms:FileFormat></dcterms:FileFormat>
   </rdf:Description>
-
-  <rdf:Description rdf:about="http://vocab.sti2.at/vrank#rdf">
-    <dcterms:FileFormat></dcterms:FileFormat>
+  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+    <owl:versionInfo>v2.0</owl:versionInfo>
   </rdf:Description>
-
-  <foaf:Person rdf:about="http://vocab.sti2.at/vrank#andtha">
+  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+    <dc:creator rdf:resource="http://dblp.org/pers/t/Thalhammer_0001:Andreas"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+    <dc:creator rdf:resource="http://dblp.org/pers/r/Roa=Valverde:Antonio_J="/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+    <dc:creator rdf:resource="http://dblp.org/pers/t/Toma:Ioan"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dblp.org/pers/t/Thalhammer_0001:Andreas">
+    <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dblp.org/pers/t/Thalhammer_0001:Andreas">
     <foaf:name>Andreas Thalhammer</foaf:name>
-    <foaf:homepage></foaf:homepage>
-  </foaf:Person>
-
-  <dcterms:Agent rdf:about="http://vocab.sti2.at/vrank#STI%20Innsbruck">
-    <foaf:member rdf:resource="http://vocab.sti2.at/vrank#andtha"/>
-    <foaf:member rdf:resource="http://vocab.sti2.at/vrank#aroa"/>
-    <foaf:member rdf:resource="http://vocab.sti2.at/vrank#itoma"/>
-    <foaf:name>STI Innsbruck</foaf:name>
-    <foaf:homepage></foaf:homepage>
-  </dcterms:Agent>
-
-  <foaf:Person rdf:about="http://vocab.sti2.at/vrank#aroa">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dblp.org/pers/t/Thalhammer_0001:Andreas">
+    <foaf:homepage rdf:resource="http://andreas.thalhammer.bayern"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dblp.org/pers/r/Roa=Valverde:Antonio_J=">
+    <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dblp.org/pers/r/Roa=Valverde:Antonio_J=">
     <foaf:name>Antonio J. Roa-Valverde</foaf:name>
-    <foaf:homepage></foaf:homepage>
-  </foaf:Person>
-
-  <foaf:Person rdf:about="http://vocab.sti2.at/vrank#itoma">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dblp.org/pers/r/Roa=Valverde:Antonio_J=">
+    <foaf:homepage rdf:resource="https://6020peaks.github.io"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dblp.org/pers/t/Toma:Ioan">
+    <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://dblp.org/pers/t/Toma:Ioan">
     <foaf:name>Ioan Toma</foaf:name>
-    <foaf:homepage></foaf:homepage>
-  </foaf:Person>
-
-  <rdfs:Class rdf:about="http://purl.org/voc/vrank#Rank">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Rank">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Rank">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Rank">
     <rdfs:label>rank</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Rank">
     <rdfs:comment>Represents a ranking score associated with an item.</rdfs:comment>
-  </rdfs:Class>
-
-  <rdfs:Class rdf:about="http://purl.org/voc/vrank#Algorithm">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Algorithm">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Algorithm">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Algorithm">
     <rdfs:label>algorithm</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Algorithm">
     <rdfs:comment>A ranking algorithm used to compute the ranking scores associated with an item (vrank:Rank).</rdfs:comment>
-  </rdfs:Class>
-
-  <rdfs:Class rdf:about="http://purl.org/voc/vrank#Feature">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Feature">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Feature">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Feature">
     <rdfs:label>feature</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Feature">
     <rdfs:comment>A feature of a vrank:Algorithm such as Granularity, RankingFactor, etc.</rdfs:comment>
-  </rdfs:Class>
-
-  <rdfs:Class rdf:about="http://purl.org/voc/vrank#Parameter">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Parameter">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Parameter">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Parameter">
     <rdfs:label>parameter</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#Parameter">
     <rdfs:comment>A parameter of a vrank:Algorithm such as number of iterations or damping factor.</rdfs:comment>
-  </rdfs:Class>
-
-  <rdf:Property rdf:about="http://purl.org/voc/vrank#computedBy">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#computedBy">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#computedBy">
     <rdfs:label>computed by</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#computedBy">
     <rdfs:comment>A vrank:Rank is computed by an vrank:Algorithm.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#computedBy">
     <rdfs:domain rdf:resource="http://purl.org/voc/vrank#Rank"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#computedBy">
     <rdfs:range rdf:resource="http://purl.org/voc/vrank#Algorithm"/>
-  </rdf:Property>
-
-  <rdf:Property rdf:about="http://purl.org/voc/vrank#hasFeature">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasFeature">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasFeature">
     <rdfs:label>has feature</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasFeature">
     <rdfs:comment>TODO.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasFeature">
     <rdfs:domain rdf:resource="http://purl.org/voc/vrank#Algorithm"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasFeature">
     <rdfs:range rdf:resource="http://purl.org/voc/vrank#Feature"/>
-  </rdf:Property>
-
-  <rdf:Property rdf:about="http://purl.org/voc/vrank#hasParameter">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasParameter">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasParameter">
     <rdfs:label>has parameter</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasParameter">
     <rdfs:comment>TODO.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasParameter">
     <rdfs:domain rdf:resource="http://purl.org/voc/vrank#Algorithm"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasParameter">
     <rdfs:range rdf:resource="http://purl.org/voc/vrank#Parameter"/>
-  </rdf:Property>
-
-  <rdf:Property rdf:about="http://purl.org/voc/vrank#hasRank">
-    <rdfs:label>has rank</rdfs:label>
-    <rdfs:comment>A subject, property or object hasRank a vrank:Rank.</rdfs:comment>
-    <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-    <rdfs:range rdf:resource="http://purl.org/voc/vrank#Rank"/>
-  </rdf:Property>
-
-  <rdf:Property rdf:about="http://purl.org/voc/vrank#hasName">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasName">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasName">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasName">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasName">
     <rdfs:label>has name</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasName">
     <rdfs:comment>A vrank:Algorithm has a name.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasName">
     <rdfs:domain rdf:resource="http://purl.org/voc/vrank#Algorithm"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasName">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-  </rdf:Property>
-
-  <rdf:Property rdf:about="http://purl.org/voc/vrank#hasRankTimeStamp">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasRankTimeStamp">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasRankTimeStamp">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasRankTimeStamp">
     <rdfs:label>has rank timestamp</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasRankTimeStamp">
     <rdfs:comment>The time when a vrank:Rank was computed.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasRankTimeStamp">
     <rdfs:domain rdf:resource="http://purl.org/voc/vrank#Rank"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasRankTimeStamp">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#datetime"/>
-  </rdf:Property>
-
-  <rdf:Property rdf:about="http://purl.org/voc/vrank#rankValue">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasRank">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasRank">
+    <rdfs:label>has rank</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasRank">
+    <rdfs:comment>A subject, property or object hasRank a vrank:Rank.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasRank">
+    <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#hasRank">
+    <rdfs:range rdf:resource="http://purl.org/voc/vrank#Rank"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#rankValue">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#rankValue">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#rankValue">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#rankValue">
     <rdfs:label>has rank value</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#rankValue">
     <rdfs:comment>The numerical value associated to a vrank:Rank.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#rankValue">
     <rdfs:domain rdf:resource="http://purl.org/voc/vrank#Rank"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#rankValue">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
-  </rdf:Property>
-
-  <rdf:Property rdf:about="http://purl.org/voc/vrank#paramId">
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="genid1">
+    <rdf:first rdf:resource="http://purl.org/voc/vrank#rankValue"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="genid1">
+    <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="genid2">
+    <rdf:first rdf:resource="http://purl.org/voc/vrank#hasRank"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="genid2">
+    <rdf:rest rdf:nodeID="genid1"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#simpleRank">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#simpleRank">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#simpleRank">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#simpleRank">
+    <owl:propertyChainAxiom rdf:nodeID="genid2"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#simpleRank">
+    <rdfs:label>rank</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#simpleRank">
+    <rdfs:comment>Directly connects owl:Thing with ranking values.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#simpleRank">
+    <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#simpleRank">
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#pagerank">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#pagerank">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#pagerank">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#pagerank">
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/voc/vrank#simpleRank"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#pagerank">
+    <rdfs:label>pagerank</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#pagerank">
+    <rdfs:comment>Directly connects owl:Thing with PageRrank values.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#pagerank">
+    <rdfs:domain rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#pagerank">
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#paramId">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#paramId">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#paramId">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#paramId">
     <rdfs:label>parameter id</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#paramId">
     <rdfs:comment>The id associated to a vrank:Parameter.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#paramId">
     <rdfs:domain rdf:resource="http://purl.org/voc/vrank#Parameter"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#paramId">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-  </rdf:Property>
-
-  <rdf:Property rdf:about="http://purl.org/voc/vrank#paramValue">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#paramValue">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#paramValue">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#paramValue">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#paramValue">
     <rdfs:label>parameter value</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#paramValue">
     <rdfs:comment>The value associated to a vrank:Parameter.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#paramValue">
     <rdfs:domain rdf:resource="http://purl.org/voc/vrank#Parameter"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#paramValue">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-  </rdf:Property>
-
-  <rdf:Property rdf:about="http://purl.org/voc/vrank#featureId">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#featureId">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#featureId">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#featureId">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#featureId">
     <rdfs:label>feature id</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#featureId">
     <rdfs:comment>The id associated to a vrank:Feature.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#featureId">
     <rdfs:domain rdf:resource="http://purl.org/voc/vrank#Feature"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#featureId">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-  </rdf:Property>
-
-  <rdf:Property rdf:about="http://purl.org/voc/vrank#featureValue">
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#featureValue">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#featureValue">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#featureValue">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#featureValue">
     <rdfs:label>feature value</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#featureValue">
     <rdfs:comment>The value associated to a vrank:Feature.</rdfs:comment>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#featureValue">
     <rdfs:domain rdf:resource="http://purl.org/voc/vrank#Feature"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank#featureValue">
     <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-  </rdf:Property>
-
+  </rdf:Description>
 </rdf:RDF>

--- a/vrank.rdf
+++ b/vrank.rdf
@@ -1,39 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:vann="http://purl.org/vocab/vann/" xmlns:vrank="http://purl.org/voc/vrank#" xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+  <rdf:Description rdf:about="http://purl.org/voc/vrank">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+  <rdf:Description rdf:about="http://purl.org/voc/vrank">
+    <owl:sameAs rdf:resource="http://vocab.sti2.at/vrank"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/voc/vrank">
     <dcterms:title>Vocabulary for Ranking (vRank)</dcterms:title>
   </rdf:Description>
-  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+  <rdf:Description rdf:about="http://purl.org/voc/vrank">
     <dcterms:description>The Vocabulary for Ranking (vRank) is an RDF Schema vocabulary for materializing ranking computations.</dcterms:description>
   </rdf:Description>
-  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+  <rdf:Description rdf:about="http://purl.org/voc/vrank">
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2017-10-31</dcterms:modified>
   </rdf:Description>
-  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+  <rdf:Description rdf:about="http://purl.org/voc/vrank">
     <vann:preferredNamespaceUri>http://purl.org/voc/vrank#</vann:preferredNamespaceUri>
   </rdf:Description>
-  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+  <rdf:Description rdf:about="http://purl.org/voc/vrank">
     <vann:preferredNamespacePrefix>vrank</vann:preferredNamespacePrefix>
   </rdf:Description>
-  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+  <rdf:Description rdf:about="http://purl.org/voc/vrank">
     <foaf:homepage rdf:resource="https://github.com/6020peaks/vRank"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+  <rdf:Description rdf:about="http://purl.org/voc/vrank">
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2012-06-05</dcterms:created>
   </rdf:Description>
-  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+  <rdf:Description rdf:about="http://purl.org/voc/vrank">
     <owl:versionInfo>v2.0</owl:versionInfo>
   </rdf:Description>
-  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+  <rdf:Description rdf:about="http://purl.org/voc/vrank">
     <dc:creator rdf:resource="http://dblp.org/pers/t/Thalhammer_0001:Andreas"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+  <rdf:Description rdf:about="http://purl.org/voc/vrank">
     <dc:creator rdf:resource="http://dblp.org/pers/r/Roa=Valverde:Antonio_J="/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://vocab.sti2.at/vrank">
+  <rdf:Description rdf:about="http://purl.org/voc/vrank">
     <dc:creator rdf:resource="http://dblp.org/pers/t/Toma:Ioan"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://dblp.org/pers/t/Thalhammer_0001:Andreas">

--- a/vrank.ttl
+++ b/vrank.ttl
@@ -11,20 +11,17 @@
 <http://vocab.sti2.at/vrank> a owl:Ontology;
     dcterms:title "Vocabulary for Ranking (vRank)";
     dcterms:description "The Vocabulary for Ranking (vRank) is an RDF Schema vocabulary for materializing ranking computations.";
-    dcterms:modified "2012-06-05"^^xsd:date;
+    dcterms:modified "2017-10-31"^^xsd:date;
     vann:preferredNamespaceUri "http://purl.org/voc/vrank#";
     vann:preferredNamespacePrefix "vrank";
-    foaf:homepage <http://vocab.sti2.at/vrank.html>;
+    foaf:homepage <https://github.com/6020peaks/vRank>;
     dcterms:created "2012-06-05"^^xsd:date;
-    dcterms:publisher "http://vocab.sti2.at/vrank#STI%20Innsbruck";
-    dcterms:partOf <http://vocab.sti2.at>;
     dcterms:type <http://purl.org/adms/assettype/Ontology>;
-    dcterms:status <http://purl.org/adms/status/UnderDevelopment>;
-    owl:versionInfo "v1.0";
+    owl:versionInfo "v2.0";
     dc:creator
-        <http://vocab.sti2.at/vrank#andtha>,
-        <http://vocab.sti2.at/vrank#aroa>,
-        <http://vocab.sti2.at/vrank#itoma> .
+        <http://dblp.org/pers/t/Thalhammer_0001:Andreas>,
+        <http://dblp.org/pers/r/Roa=Valverde:Antonio_J=>,
+        <http://dblp.org/pers/t/Toma:Ioan> .
 
 <http://vocab.sti2.at/vrank#ttl>
     dcterms:FileFormat <> .
@@ -32,25 +29,16 @@
 <http://vocab.sti2.at/vrank#rdf>
     dcterms:FileFormat <> .
 
-<http://vocab.sti2.at/vrank#andtha> a foaf:Person;
+<http://dblp.org/pers/t/Thalhammer_0001:Andreas> a foaf:Person;
     foaf:name "Andreas Thalhammer";
-    foaf:homepage <> .
+    foaf:homepage <http://andreas.thalhammer.bayern> .
 
-<http://vocab.sti2.at/vrank#STI%20Innsbruck> a dcterms:Agent;
-    foaf:member
-        <http://vocab.sti2.at/vrank#andtha>,
-        <http://vocab.sti2.at/vrank#aroa>,
-        <http://vocab.sti2.at/vrank#itoma>;
-    foaf:name "STI Innsbruck";
-    foaf:homepage <> .
-
-<http://vocab.sti2.at/vrank#aroa> a foaf:Person;
+<http://dblp.org/pers/r/Roa=Valverde:Antonio_J=> a foaf:Person;
     foaf:name "Antonio J. Roa-Valverde";
-    foaf:homepage <> .
+    foaf:homepage <https://6020peaks.github.io/> .
 
-<http://vocab.sti2.at/vrank#itoma> a foaf:Person;
-    foaf:name "Ioan Toma";
-    foaf:homepage <> .
+<http://dblp.org/pers/t/Toma:Ioan> a foaf:Person;
+    foaf:name "Ioan Toma" .
 
 vrank:Rank a rdfs:Class, owl:Class;
     rdfs:label "rank";

--- a/vrank.ttl
+++ b/vrank.ttl
@@ -16,18 +16,11 @@
     vann:preferredNamespacePrefix "vrank";
     foaf:homepage <https://github.com/6020peaks/vRank>;
     dcterms:created "2012-06-05"^^xsd:date;
-    dcterms:type <http://purl.org/adms/assettype/Ontology>;
     owl:versionInfo "v2.0";
     dc:creator
         <http://dblp.org/pers/t/Thalhammer_0001:Andreas>,
         <http://dblp.org/pers/r/Roa=Valverde:Antonio_J=>,
         <http://dblp.org/pers/t/Toma:Ioan> .
-
-<http://vocab.sti2.at/vrank#ttl>
-    dcterms:FileFormat <> .
-
-<http://vocab.sti2.at/vrank#rdf>
-    dcterms:FileFormat <> .
 
 <http://dblp.org/pers/t/Thalhammer_0001:Andreas> a foaf:Person;
     foaf:name "Andreas Thalhammer";
@@ -35,7 +28,7 @@
 
 <http://dblp.org/pers/r/Roa=Valverde:Antonio_J=> a foaf:Person;
     foaf:name "Antonio J. Roa-Valverde";
-    foaf:homepage <https://6020peaks.github.io/> .
+    foaf:homepage <https://6020peaks.github.io> .
 
 <http://dblp.org/pers/t/Toma:Ioan> a foaf:Person;
     foaf:name "Ioan Toma" .
@@ -74,12 +67,6 @@ vrank:hasParameter a rdf:Property;
     rdfs:domain vrank:Algorithm;
     rdfs:range vrank:Parameter .
 
-vrank:hasRank a rdf:Property;
-    rdfs:label "has rank";
-    rdfs:comment "A subject, property or object hasRank a vrank:Rank.";
-    rdfs:domain owl:Thing;
-    rdfs:range vrank:Rank .
-
 vrank:hasName a rdf:Property, owl:DatatypeProperty, owl:FunctionalProperty;
     rdfs:label "has name";
     rdfs:comment "A vrank:Algorithm has a name.";
@@ -92,10 +79,30 @@ vrank:hasRankTimeStamp a rdf:Property, owl:FunctionalProperty;
     rdfs:domain vrank:Rank;
     rdfs:range xsd:datetime .
 
+vrank:hasRank a rdf:Property;
+    rdfs:label "has rank";
+    rdfs:comment "A subject, property or object hasRank a vrank:Rank.";
+    rdfs:domain owl:Thing;
+    rdfs:range vrank:Rank .
+
 vrank:rankValue a rdf:Property, owl:DatatypeProperty, owl:FunctionalProperty;
     rdfs:label "has rank value";
     rdfs:comment "The numerical value associated to a vrank:Rank.";
     rdfs:domain vrank:Rank;
+    rdfs:range xsd:float .
+
+vrank:simpleRank a rdf:Property, owl:DatatypeProperty, owl:FunctionalProperty;
+    owl:propertyChainAxiom (vrank:hasRank vrank:rankValue) ;
+    rdfs:label "rank";
+    rdfs:comment "Directly connects owl:Thing with ranking values.";
+    rdfs:domain owl:Thing;
+    rdfs:range xsd:float .
+
+vrank:pagerank a rdf:Property, owl:DatatypeProperty, owl:FunctionalProperty;
+    rdfs:subPropertyOf vrank:simpleRank ;
+    rdfs:label "pagerank";
+    rdfs:comment "Directly connects owl:Thing with PageRrank values.";
+    rdfs:domain owl:Thing;
     rdfs:range xsd:float .
 
 vrank:paramId a rdf:Property, owl:DatatypeProperty, owl:FunctionalProperty;

--- a/vrank.ttl
+++ b/vrank.ttl
@@ -8,7 +8,8 @@
 @prefix vrank: <http://purl.org/voc/vrank#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://vocab.sti2.at/vrank> a owl:Ontology;
+<http://purl.org/voc/vrank> a owl:Ontology;
+    owl:sameAs <http://vocab.sti2.at/vrank> ; # compatibility to v1.0
     dcterms:title "Vocabulary for Ranking (vRank)";
     dcterms:description "The Vocabulary for Ranking (vRank) is an RDF Schema vocabulary for materializing ranking computations.";
     dcterms:modified "2017-10-31"^^xsd:date;

--- a/vrank.ttl
+++ b/vrank.ttl
@@ -57,13 +57,13 @@ vrank:computedBy a rdf:Property;
 
 vrank:hasFeature a rdf:Property;
     rdfs:label "has feature";
-    rdfs:comment "TODO.";
+    rdfs:comment "Relates vrank:Algorithm with vrank:Feature.";
     rdfs:domain vrank:Algorithm;
     rdfs:range vrank:Feature .
 
 vrank:hasParameter a rdf:Property;
     rdfs:label "has parameter";
-    rdfs:comment "TODO.";
+    rdfs:comment "Relates vrank:Algorithm with vrank:Parameter.";
     rdfs:domain vrank:Algorithm;
     rdfs:range vrank:Parameter .
 

--- a/vrank.ttl
+++ b/vrank.ttl
@@ -101,7 +101,7 @@ vrank:simpleRank a rdf:Property, owl:DatatypeProperty, owl:FunctionalProperty;
 vrank:pagerank a rdf:Property, owl:DatatypeProperty, owl:FunctionalProperty;
     rdfs:subPropertyOf vrank:simpleRank ;
     rdfs:label "pagerank";
-    rdfs:comment "Directly connects owl:Thing with PageRrank values.";
+    rdfs:comment "Directly connects owl:Thing with PageRank values.";
     rdfs:domain owl:Thing;
     rdfs:range xsd:float .
 


### PR DESCRIPTION
The file vrank.rdf was automatically translated from vrank.ttl (so it contains many changes that can be ignored, such as reordering of elements). The changes to the ontology are clearly visible in the diff of vrank.ttl.